### PR TITLE
Fix perverse sociality icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,27 +86,27 @@
         <h1>perverse sociality </h1>
         <ul>
           <li>
-            <img src="images/instagram_icon.png" alt="Instagram icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/instagram.svg" alt="Instagram icon" class="icon" />
             <a href="https://www.instagram.com/cheap_sensationalism?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==">instagram</a>
           </li>
           <li>
-            <img src="images/facebook_icon.png" alt="Facebook icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/facebook.svg" alt="Facebook icon" class="icon" />
             <a href="https://www.facebook.com/profile.php?id=61568710893706">facebook</a>
           </li>
           <li>
-            <img src="images/tiktok_icon.png" alt="TikTok icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/tiktok.svg" alt="TikTok icon" class="icon" />
             <a href="https://www.tiktok.com/@cheap_sensationalism?is_from_webapp=1&sender_device=pc">tiktok</a>
           </li>
           <li>
-            <img src="images/bluesky_icon.png" alt="Bluesky icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/bluesky.svg" alt="Bluesky icon" class="icon" />
             <a href="https://bsky.app/profile/cheap-sensations.bsky.social">bluesky</a>
           </li>
           <li>
-            <img src="images/medium_icon.png" alt="Medium icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/medium.svg" alt="Medium icon" class="icon" />
             <a href="https://medium.com/cheap-sensationalism">medium</a>
           </li>
           <li>
-            <img src="images/substack_icon.png" alt="Substack icon" />
+            <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/substack.svg" alt="Substack icon" class="icon" />
             <a href="https://substack.com/@cheapsensations">substack</a>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- fix broken icons for social media links by referencing icons from simple-icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847af21d65883218f4ed05a738c7151