### PR TITLE
Move GitHub and email section into page footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,21 +113,18 @@
       </section>
       <br>
 
-      <!-- More Info: GitHub + Email -->
-      <section>
-        <h2>More Info</h2>
-        <ul>
-          <li>
-            <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub icon", class = "icon" />
-            <a href="https://github.com/BrightsizeLife/cheapsenseReboot">GitHub</a>
-          </li>
-          <li>
-            <img src="https://em-content.zobj.net/source/google/412/envelope_2709-fe0f.png" alt="Email icon" class = "icon" />
-            <a href="mailto:ddebellis@gmail.com">example@yourdomain.com</a>
-          </li>
-        </ul>
-      </section>
-      <br>
     </main>
+    <footer>
+      <ul>
+        <li>
+          <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub icon" class="icon" />
+          <a href="https://github.com/BrightsizeLife/cheapsenseReboot">GitHub</a>
+        </li>
+        <li>
+          <img src="https://em-content.zobj.net/source/google/412/envelope_2709-fe0f.png" alt="Email icon" class="icon" />
+          <a href="mailto:ddebellis@gmail.com">example@yourdomain.com</a>
+        </li>
+      </ul>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move GitHub and email links from the `More Info` section into a footer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68570b2a82148321b382daec597d6620