### PR TITLE
Add sticky site header without album art

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,15 +18,15 @@
   </head>
   <body>
     <!-- Header/Banner -->
-    <header>
+    <header class="main-header">
       <h1 class="site-title">CHEAP SENSATIONALISM</h1>
-      <!-- Placeholder for album cover image -->
-      <img
-        src="images/albumCover.jpg"
-        alt="the new album cover with an elephant"
-        class="album-art"
-      />
     </header>
+    <!-- Album art should scroll with the page, so it lives outside the sticky header -->
+    <img
+      src="images/albumCover.jpg"
+      alt="the new album cover with an elephant"
+      class="album-art"
+    />
 
     <main>
       <!-- Section: Noises -->

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,14 @@ main {
   padding: 2rem;
 }
 
+/* Keep the main header visible while scrolling */
+.main-header {
+  position: sticky;
+  top: 0;
+  background: var(--background-color);
+  z-index: 1000;
+}
+
 /* =============================
    HEADINGS
 ============================= */


### PR DESCRIPTION
## Summary
- keep only the heading inside the sticky header
- move the album cover below the header
- scope sticky CSS to `.main-header`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685710d9de6883219c2ca61a11a7b3fc